### PR TITLE
Size parameter added for month picker

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,6 +57,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       firstEnabledMonth: 3,
                       lastEnabledMonth: 10,
                       firstYear: 2000,
+                      size: const Size(520, 250),
                       lastYear: 2025,
                       selectButtonText: 'OK',
                       cancelButtonText: 'Cancel',

--- a/lib/src/views/custom_month_picker.dart
+++ b/lib/src/views/custom_month_picker.dart
@@ -22,6 +22,7 @@ void showMonthPicker(context,
     String selectButtonText = "OK",
     String cancelButtonText = "Cancel",
     Color highlightColor = Colors.green,
+    Size? size,
     Color? contentBackgroundColor = Colors.white,
     Color? dialogBackgroundColor,
     Color? textColor}) {
@@ -72,6 +73,7 @@ void showMonthPicker(context,
       builder: (BuildContext ctx) {
         return _CustomMonthPicker(
             onSelected: onSelected,
+            size: size,
             firstYear: firstYear,
             initialSelectedMonth: initialSelectedMonth,
             initialSelectedYear: initialSelectedYear,
@@ -91,6 +93,7 @@ class _CustomMonthPicker extends StatefulWidget {
   const _CustomMonthPicker({
     Key? key,
     required this.onSelected,
+    this.size,
     this.firstYear,
     this.initialSelectedMonth,
     this.initialSelectedYear,
@@ -118,7 +121,7 @@ class _CustomMonthPicker extends StatefulWidget {
   final Color? textColor;
   final Color? dialogBackgroundColor;
   final Color? contentBackgroundColor;
-
+  final Size? size;
   @override
   State<_CustomMonthPicker> createState() => _CustomMonthPickerState();
 }
@@ -150,7 +153,9 @@ class _CustomMonthPickerState extends State<_CustomMonthPicker> {
       shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(15.0))),
       content: SizedBox(
-        width: MediaQuery.of(context).size.width,
+        width: widget.size == null
+            ? MediaQuery.of(context).size.width
+            : widget.size!.width,
         child: Obx(
           () => Column(
             mainAxisSize: MainAxisSize.min,
@@ -254,7 +259,10 @@ class _CustomMonthPickerState extends State<_CustomMonthPicker> {
               borderRadius: BorderRadius.circular(10.0),
             ),
           ),
-          child: Text(widget.selectButtonText!),
+          child: Text(
+            widget.selectButtonText!,
+            style: const TextStyle(color: Colors.white),
+          ),
         ),
         const SizedBox(width: 15),
       ],

--- a/test/flutter_custom_month_picker_test.dart
+++ b/test/flutter_custom_month_picker_test.dart
@@ -1,5 +1,3 @@
-import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_custom_month_picker/flutter_custom_month_picker.dart';
 
 void main() {}


### PR DESCRIPTION
For desktop platform it was taking full view size. That's why added size parameter so user can limit the size of the month picker.